### PR TITLE
 Upgrade HTML output to support various CLI options

### DIFF
--- a/src/formattedcode/output_html.py
+++ b/src/formattedcode/output_html.py
@@ -137,7 +137,7 @@ class CustomTemplateOutput(OutputPlugin):
         license_references = []
         if hasattr(codebase.attributes, 'license_references'):
             license_references = codebase.attributes.license_references
-        summary = None 
+        summary = None
         if hasattr(codebase.attributes, 'summary'):
             summary = codebase.attributes.summary
         template_loc = custom_template
@@ -206,7 +206,7 @@ def generate_output(results, license_references, summary, version, template):
     converted = {}
     converted_infos = {}
     converted_packages = {}
-    licenses = {} 
+    licenses = {}
 
     LICENSES = 'license_detections'
     COPYRIGHTS = 'copyrights'

--- a/src/formattedcode/output_html.py
+++ b/src/formattedcode/output_html.py
@@ -43,7 +43,7 @@ which is NOT a plugin
 TEMPLATES_DIR = join(dirname(__file__), 'templates')
 
 
-TRACE = False
+TRACE = True
 
 
 def logger_debug(*args):
@@ -83,12 +83,16 @@ class HtmlOutput(OutputPlugin):
         license_references = []
         if hasattr(codebase.attributes, 'license_references'):
             license_references = codebase.attributes.license_references
+        summary = None
+        if hasattr(codebase.attributes, 'summary'):
+            summary = codebase.attributes.summary
         template_loc = join(TEMPLATES_DIR, 'html', 'template.html')
         output_file = html
         write_templated(
             output_file=output_file,
             results=results,
             license_references=license_references,
+            summary=summary,
             version=version,
             template_loc=template_loc,
         )
@@ -133,18 +137,22 @@ class CustomTemplateOutput(OutputPlugin):
         license_references = []
         if hasattr(codebase.attributes, 'license_references'):
             license_references = codebase.attributes.license_references
+        summary = None 
+        if hasattr(codebase.attributes, 'summary'):
+            summary = codebase.attributes.summary
         template_loc = custom_template
         output_file = custom_output
         write_templated(
             output_file=output_file,
             results=results,
             license_references=license_references,
+            summary=summary,
             version=version,
             template_loc=template_loc
         )
 
 
-def write_templated(output_file, results, license_references, version, template_loc):
+def write_templated(output_file, results, license_references, summary, version, template_loc):
     """
     Write scan output `results` to the `output_file` opened file using a template
     file at `template_loc`.
@@ -155,6 +163,7 @@ def write_templated(output_file, results, license_references, version, template_
     for template_chunk in generate_output(
         results=results,
         license_references=license_references,
+        summary=summary,
         version=version,
         template=template,
     ):
@@ -184,7 +193,7 @@ def get_template(location):
     return env.get_template(template_name)
 
 
-def generate_output(results, license_references, version, template):
+def generate_output(results, license_references, summary, version, template):
     """
     Yield unicode strings from incrementally rendering `results` and `version`
     with the Jinja `template` object.
@@ -197,11 +206,12 @@ def generate_output(results, license_references, version, template):
     converted = {}
     converted_infos = {}
     converted_packages = {}
-    licenses = {}
+    licenses = {} 
 
     LICENSES = 'license_detections'
     COPYRIGHTS = 'copyrights'
     PACKAGES = 'package_data'
+    logger_debug(f"summary: {summary}")
 
     # Create a flattened data dict keyed by path
     for scanned_file in results:
@@ -223,12 +233,21 @@ def generate_output(results, license_references, version, template):
                 if TRACE:
                     logger_debug(f"match: {match}")
                 license_expression = match['license_expression']
-                results.append({
+                match_data = {
                     'start': match['start_line'],
                     'end': match['end_line'],
                     'what': 'license',
                     'value': license_expression,
-                })
+                }
+
+                if 'matched_text' in match:
+                    match_data['matched_text'] = match['matched_text']
+
+                if 'matched_text_diagnostics' in match:
+                    logger_debug(match['matched_text_diagnostics'])
+                    match_data['matched_text_diagnostics'] = match['matched_text_diagnostics']
+
+                results.append(match_data)
 
                 if not license_references and license_expression not in licenses:
                     license_object = get_licenses_db().get(license_expression)
@@ -261,7 +280,7 @@ def generate_output(results, license_references, version, template):
         'package_data': converted_packages
     }
 
-    return template.generate(files=files, license_references=license_references, version=version)
+    return template.generate(files=files, license_references=license_references, summary=summary, version=version)
 
 
 @output_impl

--- a/src/formattedcode/output_html.py
+++ b/src/formattedcode/output_html.py
@@ -43,7 +43,7 @@ which is NOT a plugin
 TEMPLATES_DIR = join(dirname(__file__), 'templates')
 
 
-TRACE = True
+TRACE = False
 
 
 def logger_debug(*args):
@@ -211,7 +211,6 @@ def generate_output(results, license_references, summary, version, template):
     LICENSES = 'license_detections'
     COPYRIGHTS = 'copyrights'
     PACKAGES = 'package_data'
-    logger_debug(f"summary: {summary}")
 
     # Create a flattened data dict keyed by path
     for scanned_file in results:
@@ -244,7 +243,6 @@ def generate_output(results, license_references, summary, version, template):
                     match_data['matched_text'] = match['matched_text']
 
                 if 'matched_text_diagnostics' in match:
-                    logger_debug(match['matched_text_diagnostics'])
                     match_data['matched_text_diagnostics'] = match['matched_text_diagnostics']
 
                 results.append(match_data)

--- a/src/formattedcode/templates/html/template.html
+++ b/src/formattedcode/templates/html/template.html
@@ -46,41 +46,41 @@
         font-weight: normal;
         font-size: 12px;
       }
-        details {
-            margin: 5px 0;
-        }
-        summary {
-            cursor: pointer;
-            color: #5E81B7;
-            font-weight: bold;
-        }
-        summary:hover {
-            text-decoration: underline;
-        }
-        pre {
-            background: #f5f5f5;
-            padding: 10px;
-            border: 1px solid #ddd;
-            overflow-x: auto;
-            font-family: monospace;
-            font-size: 11px;
-            white-space: pre-wrap;
-            word-wrap: break-word;
-        }
-        .summary-section {
-            background: #f0f8ff;
-            padding: 15px;
-            margin-bottom: 20px;
-            border-left: 4px solid #5E81B7;
-        }
-        .summary-section h3 {
-            margin-top: 0;
-            color: #5E81B7;
-            font-size: 16px;
-        }
-        .summary-section p {
-            margin: 5px 0;
-        }
+      details {
+          margin: 5px 0;
+      }
+      summary {
+          cursor: pointer;
+          color: #5E81B7;
+          font-weight: bold;
+      }
+      summary:hover {
+          text-decoration: underline;
+      }
+      pre {
+          background: #f5f5f5;
+          padding: 10px;
+          border: 1px solid #ddd;
+          overflow-x: auto;
+          font-family: monospace;
+          font-size: 11px;
+          white-space: pre-wrap;
+          word-wrap: break-word;
+      }
+      .summary-section {
+          background: #f0f8ff;
+          padding: 15px;
+          margin-bottom: 20px;
+          border-left: 4px solid #5E81B7;
+      }
+      .summary-section h3 {
+          margin-top: 0;
+          color: #5E81B7;
+          font-size: 16px;
+      }
+      .summary-section p {
+          margin: 5px 0;
+      }
     </style>
   </head>
   <body>
@@ -108,7 +108,7 @@
       <p><strong>Other Holders:</strong></p>
       <ul>
         {% for holder in summary.other_holders %}
-        <li>{{ holder }}</li>
+        <li>{{ holder.value }}{% if holder.count is not none %} (count: {{ holder.count }}){% endif %}</li>
         {% endfor %}
       </ul>
       {% endif %}

--- a/src/formattedcode/templates/html/template.html
+++ b/src/formattedcode/templates/html/template.html
@@ -46,9 +46,101 @@
         font-weight: normal;
         font-size: 12px;
       }
+        details {
+            margin: 5px 0;
+        }
+        summary {
+            cursor: pointer;
+            color: #5E81B7;
+            font-weight: bold;
+        }
+        summary:hover {
+            text-decoration: underline;
+        }
+        pre {
+            background: #f5f5f5;
+            padding: 10px;
+            border: 1px solid #ddd;
+            overflow-x: auto;
+            font-family: monospace;
+            font-size: 11px;
+            white-space: pre-wrap;
+            word-wrap: break-word;
+        }
+        .summary-section {
+            background: #f0f8ff;
+            padding: 15px;
+            margin-bottom: 20px;
+            border-left: 4px solid #5E81B7;
+        }
+        .summary-section h3 {
+            margin-top: 0;
+            color: #5E81B7;
+            font-size: 16px;
+        }
+        .summary-section p {
+            margin: 5px 0;
+        }
     </style>
   </head>
   <body>
+    {% if summary %}
+    <div class="summary-section">
+      <h3>Scan Summary</h3>
+      {% if summary.declared_license_expression %}
+      <p><strong>Declared License:</strong> {{ summary.declared_license_expression }}</p>
+      {% endif %}
+      {% if summary.declared_holder %}
+      <p><strong>Declared Holder:</strong> {{ summary.declared_holder }}</p>
+      {% endif %}
+      {% if summary.primary_language %}
+      <p><strong>Primary Language:</strong> {{ summary.primary_language }}</p>
+      {% endif %}
+      {% if summary.other_license_expressions %}
+      <p><strong>Other License Expressions:</strong></p>
+      <ul>
+        {% for expr in summary.other_license_expressions %}
+        <li>{{ expr.value }} (count: {{ expr.count }})</li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+      {% if summary.other_holders %}
+      <p><strong>Other Holders:</strong></p>
+      <ul>
+        {% for holder in summary.other_holders %}
+        <li>{{ holder }}</li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+    </div>
+    {% endif %}
+    {% if summary and summary.license_clarity_score %}
+    <table>
+      <caption>License Clarity Score</caption>
+      <thead>
+        <tr>
+          <th>Overall Score</th>
+          <th>Declared License</th>
+          <th>Identification Precision</th>
+          <th>Has License Text</th>
+          <th>Declared Copyrights</th>
+          <th>Ambiguous Compound</th>
+          <th>Conflicting Categories</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>{{ summary.license_clarity_score.score }}</strong></td>
+          <td>{{ summary.license_clarity_score.declared_license }}</td>
+          <td>{{ summary.license_clarity_score.identification_precision }}</td>
+          <td>{{ summary.license_clarity_score.has_license_text }}</td>
+          <td>{{ summary.license_clarity_score.declared_copyrights }}</td>
+          <td>{{ summary.license_clarity_score.ambiguous_compound_licensing }}</td>
+          <td>{{ summary.license_clarity_score.conflicting_license_categories }}</td>
+        </tr>
+      </tbody>
+    </table>
+    {% endif %}
     {% if files.license_copyright %}
     <table>
       <caption>Copyrights and Licenses Information</caption>
@@ -59,6 +151,7 @@
           <th>end</th>
           <th>what</th>
           <th>value</th>
+          <th>matched text/ diagnostics</th>
         </tr>
       </thead>
       <tbody>
@@ -71,6 +164,23 @@
               <td>{{ row.what }}</td>
               {% if row.what == 'license' %}
                 <td><a href="#license_{{ row.value }}">{{ row.value }}</a></td>
+                <td>
+                  {% if row.matched_text %}
+                  <details>
+                    <summary>View Matched Text</summary>
+                    <pre>{{ row.matched_text|escape }}</pre>
+                  </details>
+                  {% endif %}
+                  {% if row.matched_text_diagnostics %}
+                  <details>
+                    <summary>View Diagnostics</summary>
+                    <pre>{{ row.matched_text_diagnostics|escape }}</pre>
+                  </details>
+                  {% endif %}
+                  {% if not row.matched_text and not row.matched_text_diagnostics %}
+                  -
+                  {% endif %}
+                </td>
               {% else %}
                 <td>{{ row.value|escape }}</td>
               {% endif %}

--- a/src/formattedcode/templates/html/template.html
+++ b/src/formattedcode/templates/html/template.html
@@ -183,6 +183,7 @@
                 </td>
               {% else %}
                 <td>{{ row.value|escape }}</td>
+                <td></td>
               {% endif %}
             </tr>
           {% endfor %}

--- a/tests/formattedcode/test_output_templated.py
+++ b/tests/formattedcode/test_output_templated.py
@@ -72,6 +72,46 @@ def test_paths_are_posix_in_html_format_output():
     assert '/copyright_acme_c-c.c' in results
     assert __version__ in results
 
+@pytest.mark.scanslow
+def test_html_output_includes_license_text():
+    test_file = test_env.get_test_loc('templated/simple-license.txt')
+    result_file = test_env.get_temp_file('html')
+    run_scan_click(['--license', '--license-text', test_file, '--html', result_file])
+    results = open(result_file).read()
+    assert 'matched text' in results.lower()
+    assert '<pre>' in results  # Check for formatted text display
+    assert __version__ in results
+
+@pytest.mark.scanslow
+def test_html_output_includes_license_text_diagnostics():
+    test_file = test_env.get_test_loc('templated/simple-license.txt')
+    result_file = test_env.get_temp_file('html')
+    run_scan_click(['--license', '--license-text', '--license-text-diagnostics', 
+                    test_file, '--html', result_file])
+    results = open(result_file).read()
+    assert 'diagnostics' in results.lower()
+    assert __version__ in results
+
+@pytest.mark.scanslow
+def test_html_output_includes_license_clarity_score():
+    test_dir = test_env.get_test_loc('templated/simple')
+    result_file = test_env.get_temp_file('html')
+    run_scan_click(['--license', '--classify', '--license-clarity-score', 
+                    test_dir, '--html', result_file])
+    results = open(result_file).read()
+    assert 'License Clarity Score' in results
+    assert 'score' in results.lower()
+    assert __version__ in results
+
+@pytest.mark.scanslow
+def test_html_output_includes_summary():
+    test_dir = test_env.get_test_loc('templated/simple')
+    result_file = test_env.get_temp_file('html')
+    run_scan_click(['--license', '--classify', '--summary', 
+                    test_dir, '--html', result_file])
+    results = open(result_file).read()
+    assert 'Scan Summary' in results
+    assert __version__ in results
 
 @pytest.mark.scanslow
 def test_scanned_path_is_present_in_html_app_output():

--- a/tests/formattedcode/test_output_templated.py
+++ b/tests/formattedcode/test_output_templated.py
@@ -144,6 +144,7 @@ def test_scan_html_output_does_not_truncate_copyright_html():
           <td>1</td>
           <td>copyright</td>
             <td>Copyright \(c\) 2000 ACME, Inc\.</td>
+            <td></td>
         </tr>
     '''
 


### PR DESCRIPTION
<!-- Delete Template sections if unneccesary -->
<!-- Add issue number here (We encourage you to create the Issue First) -->
<!-- You can also link the issue in Commit Messages -->

Fixes #3281

## Description

This PR adds support for additional CLI options in HTML output to match the functionality available in JSON/YAML formats:
- `--license-text`: Display matched license text
- `--license-text-diagnostics`: Show diagnostic information for license matches
- `--summary`: Display scan summary with declared license and holder information
- `--license-clarity-score`: Show license clarity score breakdown

## Changes Made

### Template Changes (`src/formattedcode/templates/html/template.html`)
- Added **Scan Summary** section displaying:
  - Declared license expression
  - Declared holder
  - Primary language
  - Other license expressions (with counts)
  - Other holders
- Added **License Clarity Score** table showing:
  - Overall score (0-100)
  - Component metrics (declared_license, identification_precision, has_license_text, etc.)
- Enhanced **Copyrights and Licenses** table:
  - Added new column for matched text and diagnostics
  - Used HTML5 `<details>`/`<summary>` elements for collapsible sections
  - Display matched text when `--license-text` is used
  - Display diagnostics when `--license-text-diagnostics` is used
- Added CSS styling for new elements

### Code Changes (`src/formattedcode/output_html.py`)
- Modified `generate_output()` to pass `summary` parameter to `template.generate()`
- Summary data already being collected in `process_codebase()` - just needed to be passed through

## Testing

Tested with various command combinations:
```bash
# License text
scancode --license --license-text test_dir/ --html output.html

# License text with diagnostics
scancode --license --license-text --license-text-diagnostics test_dir/ --html output.html

# Summary and clarity score
scancode --license --classify --summary --license-clarity-score test_dir/ --html output.html

# All options combined
scancode --license --license-text --license-text-diagnostics --classify --summary --license-clarity-score --license-references test_dir/ --html output.html
