### PR TITLE
Fix end_line incorrectly assigned from start_line in CSV output #4785

### DIFF
--- a/src/formattedcode/output_csv.py
+++ b/src/formattedcode/output_csv.py
@@ -185,7 +185,7 @@ def flatten_scan(scan, headers):
             inf = dict(path=path)
             inf['copyright'] = copyr['copyright']
             inf['start_line'] = copyr['start_line']
-            inf['end_line'] = copyr['start_line']
+            inf['end_line'] = copyr['end_line']
             collect_keys(inf, 'copyright')
             yield inf
 
@@ -193,7 +193,7 @@ def flatten_scan(scan, headers):
             inf = dict(path=path)
             inf['holder'] = copyr['holder']
             inf['start_line'] = copyr['start_line']
-            inf['end_line'] = copyr['start_line']
+            inf['end_line'] = copyr['end_line']
             collect_keys(inf, 'copyright')
             yield inf
 
@@ -201,7 +201,7 @@ def flatten_scan(scan, headers):
             inf = dict(path=path)
             inf['author'] = copyr['author']
             inf['start_line'] = copyr['start_line']
-            inf['end_line'] = copyr['start_line']
+            inf['end_line'] = copyr['end_line']
             collect_keys(inf, 'copyright')
             yield inf
 

--- a/tests/formattedcode/data/csv/flatten_scan/full.json-expected
+++ b/tests/formattedcode/data/csv/flatten_scan/full.json-expected
@@ -3717,19 +3717,19 @@
         "path": "samples/commoncode/src/commoncode/python.LICENSE",
         "copyright": "Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008 Python Software Foundation",
         "start_line": 93,
-        "end_line": 93
+        "end_line": 94
     },
     {
         "path": "samples/commoncode/src/commoncode/python.LICENSE",
         "copyright": "Copyright (c) 1995-2001 Corporation for National Research Initiatives",
         "start_line": 194,
-        "end_line": 194
+        "end_line": 195
     },
     {
         "path": "samples/commoncode/src/commoncode/python.LICENSE",
         "copyright": "Copyright (c) 1991 - 1995, Stichting Mathematisch Centrum Amsterdam, The Netherlands",
         "start_line": 254,
-        "end_line": 254
+        "end_line": 255
     },
     {
         "path": "samples/commoncode/src/commoncode/python.LICENSE",
@@ -3741,19 +3741,19 @@
         "path": "samples/commoncode/src/commoncode/python.LICENSE",
         "copyright": "Copyright (c) 1990-2005 Sleepycat Software",
         "start_line": 331,
-        "end_line": 331
+        "end_line": 332
     },
     {
         "path": "samples/commoncode/src/commoncode/python.LICENSE",
         "copyright": "Copyright (c) 1990, 1993, 1994, 1995 The Regents of the University of California",
         "start_line": 366,
-        "end_line": 366
+        "end_line": 367
     },
     {
         "path": "samples/commoncode/src/commoncode/python.LICENSE",
         "copyright": "Copyright (c) 1995, 1996 The President and Fellows of Harvard University",
         "start_line": 394,
-        "end_line": 394
+        "end_line": 395
     },
     {
         "path": "samples/commoncode/src/commoncode/python.LICENSE",
@@ -3777,13 +3777,13 @@
         "path": "samples/commoncode/src/commoncode/python.LICENSE",
         "copyright": "copyrighted by the Regents of the University of California, Sun Microsystems, Inc., Scriptics Corporation, ActiveState Corporation",
         "start_line": 554,
-        "end_line": 554
+        "end_line": 556
     },
     {
         "path": "samples/commoncode/src/commoncode/python.LICENSE",
         "copyright": "copyrighted by the Regents of the University of California, Sun Microsystems, Inc.",
         "start_line": 597,
-        "end_line": 597
+        "end_line": 598
     },
     {
         "path": "samples/commoncode/src/commoncode/python.LICENSE",
@@ -3801,7 +3801,7 @@
         "path": "samples/commoncode/src/commoncode/python.LICENSE",
         "holder": "Stichting Mathematisch Centrum Amsterdam, The Netherlands",
         "start_line": 254,
-        "end_line": 254
+        "end_line": 255
     },
     {
         "path": "samples/commoncode/src/commoncode/python.LICENSE",
@@ -3849,13 +3849,13 @@
         "path": "samples/commoncode/src/commoncode/python.LICENSE",
         "holder": "the Regents of the University of California, Sun Microsystems, Inc., Scriptics Corporation, ActiveState Corporation",
         "start_line": 554,
-        "end_line": 554
+        "end_line": 556
     },
     {
         "path": "samples/commoncode/src/commoncode/python.LICENSE",
         "holder": "the Regents of the University of California, Sun Microsystems, Inc.",
         "start_line": 597,
-        "end_line": 597
+        "end_line": 598
     },
     {
         "path": "samples/commoncode/src/commoncode/python.LICENSE",
@@ -3873,13 +3873,13 @@
         "path": "samples/commoncode/src/commoncode/python.LICENSE",
         "author": "Eric Young (eay@cryptsoft.com)",
         "start_line": 485,
-        "end_line": 485
+        "end_line": 486
     },
     {
         "path": "samples/commoncode/src/commoncode/python.LICENSE",
         "author": "Tim Hudson (tjh@cryptsoft.com)",
         "start_line": 486,
-        "end_line": 486
+        "end_line": 487
     },
     {
         "path": "samples/commoncode/src/commoncode/python.LICENSE",
@@ -5073,7 +5073,7 @@
         "path": "samples/JGroups/licenses/apache-1.1.txt",
         "author": "the Apache Software Foundation (http://www.apache.org/)",
         "start_line": 21,
-        "end_line": 21
+        "end_line": 22
     },
     {
         "path": "samples/JGroups/licenses/apache-1.1.txt",
@@ -7245,13 +7245,13 @@
         "path": "samples/zlib/iostream2/zstream.h",
         "copyright": "Copyright (c) 1997 Christian Michelsen Research AS Advanced Computing",
         "start_line": 3,
-        "end_line": 3
+        "end_line": 5
     },
     {
         "path": "samples/zlib/iostream2/zstream.h",
         "holder": "Christian Michelsen Research AS Advanced Computing",
         "start_line": 4,
-        "end_line": 4
+        "end_line": 5
     },
     {
         "path": "samples/zlib/iostream2/zstream.h",

--- a/tests/formattedcode/test_output_csv.py
+++ b/tests/formattedcode/test_output_csv.py
@@ -97,6 +97,29 @@ def test_flatten_scan_minimal():
     check_json(result, expected_file, regen=REGEN_TEST_FIXTURES)
 
 
+@pytest.mark.parametrize('group,key', [
+    ('copyrights', 'copyright'),
+    ('holders', 'holder'),
+    ('authors', 'author'),
+])
+def test_flatten_scan_preserves_multiline_detection_ranges(group, key):
+    scan = [{
+        'path': 'example.py',
+        group: [{key: 'Example', 'start_line': 10, 'end_line': 13}],
+    }]
+    headers = {name: [] for name in ('info', 'license', 'copyright', 'email', 'url', 'package')}
+
+    rows = list(flatten_scan(scan, headers))
+
+    assert rows[1] == {
+        'path': 'example.py',
+        key: 'Example',
+        'start_line': 10,
+        'end_line': 13,
+    }
+    assert headers['copyright'] == [key, 'start_line', 'end_line']
+
+
 def test_flatten_scan_can_process_path_with_and_without_leading_slash():
     test_json = test_env.get_test_loc('csv/flatten_scan/path_with_and_without_leading_slash.json')
     scan = load_scan(test_json)


### PR DESCRIPTION
## Fix `end_line` incorrectly assigned from `start_line` in CSV output

In `flatten_scan()` in `src/formattedcode/output_csv.py`, the `end_line` field for copyrights, holders, and authors was assigned `copyr['start_line']` instead of `copyr['end_line']`. This caused the `end_line` column in CSV output to always equal `start_line`, losing the actual end line information for multi-line copyright notices.

The underlying data model (`CopyrightDetection`, `HolderDetection`, `AuthorDetection` in `src/cluecode/copyrights.py`) all define both `start_line` and `end_line` fields, and the JSON output correctly includes both values. Git blame traces this to a copy-paste error in commit `ef8086d` ("Update CSV output to latest copyright data format", ~2018).

Fixes #4785

<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [ ] Updated documentation pages (if applicable)
* [ ] Updated CHANGELOG.rst (if applicable)
<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->