### PR TITLE
Deprecate noisy freertos rule #4147

### DIFF
--- a/src/licensedcode/data/rules/gpl-2.0-plus_with_freertos-exception-2.0_1.RULE
+++ b/src/licensedcode/data/rules/gpl-2.0-plus_with_freertos-exception-2.0_1.RULE
@@ -2,6 +2,7 @@
 license_expression: gpl-2.0-plus WITH freertos-exception-2.0
 is_license_reference: yes
 relevance: 100
+is_deprecated: yes
 ignorable_urls:
     - http://www.freertos.org/
 ---


### PR DESCRIPTION
This rule is not even a clue.

Reported-by:  Min-Kyungsun @Min-Kyungsun 
Reference: https://github.com/aboutcode-org/scancode-toolkit/issues/4147
Reference: https://github.com/aboutcode-org/scancode-toolkit/issues/4441

<!-- Delete Template sections if unneccesary -->
<!-- Add issue number here (We encourage you to create the Issue First) -->
<!-- You can also link the issue in Commit Messages -->

Fixes #4147
Fixes #4441
<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [ ] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [ ] Updated documentation pages (if applicable)
* [ ] Updated CHANGELOG.rst (if applicable)
<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
