### PR TITLE
fix(copyrights): Retain trailing "Authors." when preceding name is tagged NN

### DIFF
--- a/src/cluecode/copyrights.py
+++ b/src/cluecode/copyrights.py
@@ -3288,7 +3288,10 @@ GRAMMAR = """
     COPYRIGHT: {<COPY> <COPY> <ANDCO>}  #2841
 
     # Copyright (c) 1995-2018 The PNG Reference Library Authors. (with and without trailing dot)
-    COPYRIGHT: {<COPYRIGHT> <NN> <AUTHDOT>} #35011
+    # Copyright 2021 The logr Authors. / Copyright 2022 The JSpecify Authors.
+    # attach a trailing "Authors." even when the preceding name was already
+    # absorbed into the COPYRIGHT node (e.g. names tagged NN like "logr", "JSpecify")
+    COPYRIGHT: {<COPYRIGHT> <NN>? <AUTHDOT>} #35011
 
     ############ All right reserved in the middle ##############################
 


### PR DESCRIPTION
The copyright grammar only attached a trailing AUTHDOT token ("Authors.") to a copyright when an NN sat between the COPYRIGHT node and the AUTHDOT (rule #35011).

Altered rule to match any entry that AUTHDOT recognition causing the trimming effect.

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
