### PR TITLE
fix: Reproduced the root cause on an actual Apple Silicon machine

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 Next release
 --------------
 
+- Document the Apple Silicon (M1/M2/M3/M4) ``./configure --dev`` workaround
+  in ``CONTRIBUTING.rst`` for contributors using an arm64-only Homebrew
+  Python.
+  https://github.com/aboutcode-org/scancode-toolkit/issues/4650
+
 - Fix the optional ``licenses`` extra dependency typo to install
   ``licensedcode-data``.
   https://github.com/aboutcode-org/scancode-toolkit/pull/5056

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -140,6 +140,28 @@ To set up ScanCode for local development:
 
         configure --dev
 
+   If you are on Apple Silicon (M1/M2/M3/M4) and your ``python3`` is an
+   arm64-only Homebrew install, ``./configure --dev`` may fail with an
+   error such as::
+
+       ERROR: No matching distribution found for extractcode-7z==16.5.210531
+
+   This happens because some native thirdparty dependencies do not have
+   pre-built wheels for the arm64 architecture. ``configure`` already
+   relaunches itself under Rosetta on Apple Silicon, but this only helps
+   if the Python interpreter it finds is a universal or x86_64 binary; an
+   arm64-only Homebrew Python still runs natively and the pinned arm64-less
+   dependencies fail to resolve. To work around this, install an x86_64
+   Python via Rosetta and point ``configure`` to it::
+
+       arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+       arch -x86_64 /usr/local/bin/brew install python@3.12
+       echo "/usr/local/bin/python3.12" > PYTHON_EXECUTABLE
+       ./configure --dev
+
+   See `issue #3205 <https://github.com/aboutcode-org/scancode-toolkit/issues/3205>`_
+   for more background on Apple Silicon compatibility.
+
    Then activate the virtual environment::
 
         source venv/bin/activate


### PR DESCRIPTION
Fixes #4650

<!-- Delete Template sections if unneccesary -->
<!-- Add issue number here (We encourage you to create the Issue First) -->
<!-- You can also link the issue in Commit Messages -->

Fixes #0000

<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [ ] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [ ] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [ ] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [ ] Updated documentation pages (if applicable)
* [ ] Updated CHANGELOG.rst (if applicable)
<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->

---

Reproduced the root cause on an actual Apple Silicon machine: configure's Rosetta relaunch makes the shell x86_64 but an arm64-only Homebrew python3 still execs natively as arm64 (verified via `arch -x86_64 bash -c python3 ...`), so pinned deps like extractcode-7z fail to resolve; added a CONTRIBUTING.rst note (matching the file's existing RedHat-troubleshooting-note style) documenting the failure and the x86_64-Python-via-Rosetta workaround, plus a CHANGELOG.rst entry.

**How this was tested:** `X`