### PR TITLE
Update license scripts to support YAML frontmatter changes

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -79,6 +79,7 @@ The following organizations or individuals have contributed to ScanCode:
 - Sankha Das @sankha555
 - Saravanan G @SaravananOffl
 - Sarita Singh @itssingh
+- Sarthak Shubham @sarthak-shubham
 - Savino Sguera @savinos
 - Sebastian Roth @ened
 - Sebastian Schuberth @sschuberth

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,13 @@ Next release
   ``licensedcode-data``.
   https://github.com/aboutcode-org/scancode-toolkit/pull/5056
 
+- Fix ``report_license_rules.py`` and ``buildrules.py`` in
+  ``etc/scripts/licenses/`` to work correctly with the YAML frontmatter
+  fields added in #3100.
+  https://github.com/aboutcode-org/scancode-toolkit/issues/3138
+
+
+
 v33.0.0rc1 - 2026-05-14
 ------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ Next release
 - Fix ``report_license_rules.py`` and ``buildrules.py`` in
   ``etc/scripts/licenses/`` to work correctly with the YAML frontmatter
   fields added in #3100.
-  https://github.com/aboutcode-org/scancode-toolkit/issues/3138
+  https://github.com/aboutcode-org/scancode-toolkit/pull/5259
 
 
 

--- a/etc/scripts/licenses/buildrules.py
+++ b/etc/scripts/licenses/buildrules.py
@@ -294,6 +294,7 @@ def cli(licenses_file, dump_to_file_on_errors=False):
     """
 
     rules_data = load_data(licenses_file)
+    click.echo("Loading existing rules to check for duplicates. This may take several minutes...")
     rule_by_tokens = all_rule_by_tokens()
 
     licenses_by_key = cache.get_licenses_db()

--- a/etc/scripts/licenses/report_license_rules.py
+++ b/etc/scripts/licenses/report_license_rules.py
@@ -83,8 +83,8 @@ SCANCODE_LICENSEDB_URL = "https://scancode-licensedb.aboutcode.org/{}"
 
 def write_data_to_csv(data, output_csv, fieldnames):
 
-    with open(output_csv, "w") as f:
-        w = csv.DictWriter(f, fieldnames=fieldnames)
+    with open(output_csv, "w", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=fieldnames, extrasaction='ignore')
         w.writeheader()
         for entry in data:
             w.writerow(entry)
@@ -180,6 +180,7 @@ def cli(licenses, rules, category, license_key, with_text):
     licenses_output = []
     rules_output = []
 
+    click.echo("Loading licenses from the database...")
     licenses_data = load_licenses()
 
     if licenses:
@@ -208,8 +209,10 @@ def cli(licenses, rules, category, license_key, with_text):
         write_data_to_csv(data=licenses_output, output_csv=licenses, fieldnames=LICENSES_FIELDNAMES)
 
     if rules:
-        rules_data = list(load_rules())
-        for rule in rules_data:
+        click.echo("Loading 30,000+ rules from the database. This will take several minutes, so please be patient...")
+        for i, rule in enumerate(load_rules()):
+            if i > 0 and i % 5000 == 0:
+                click.echo(f"Processed {i} rules...")
             rule_data = rule.to_dict()
             rule_data["identifier"] = rule.identifier
             rule_data["referenced_filenames"] = rule.referenced_filenames
@@ -239,6 +242,9 @@ def cli(licenses, rules, category, license_key, with_text):
 
         rules_output = flatten_output(rules_output)
         write_data_to_csv(data=rules_output, output_csv=rules, fieldnames=RULES_FIELDNAMES)
+
+    if licenses or rules:
+        click.echo("Export complete! Check your CSV files.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #3138

## What
Updated `report_license_rules.py` and `buildrules.py` in `etc/scripts/licenses/`
to work correctly with the YAML frontmatter format introduced in #3100, which
added new fields (`is_builtin`, `is_generic`, `is_continuous`, `length`) to the
`License` and `Rule` models.

### report_license_rules.py
- Added `extrasaction='ignore'` to the `csv.DictWriter` calls so the script no
  longer crashes when the models gain fields not present in the CSV column
  headers — also avoids needing to update this script every time a new model
  field is added going forward.
- Added `encoding="utf-8"` to the `open()` call in `write_data_to_csv()`, since
  the default Windows encoding (cp1252) can't handle non-ASCII characters
  (e.g. in author names) present in the license database.
- Added progress logging via `click.echo()` (start, periodic progress every
  5,000 rules, completion message) since exporting 35,000+ rules takes several
  minutes with no prior feedback that the script is working.
- Switched to streaming with `enumerate()` instead of loading all rules into a
  list upfront, to support the progress logging without changing the output.

### buildrules.py
- Added a `click.echo()` message before the duplicate-check step
  (`all_rule_by_tokens()`). This step tokenizes all 35,000+ existing rules to
  check the new rule for duplicates, which takes roughly 10 minutes on a full
  run — expected given the dataset size, but silent without the log.

## Testing
Ran both scripts manually against the current license/rule database —
report_license_rules.py completes end-to-end; buildrules.py correctly parses
an example rule file and generates a new .RULE file (deleted afterward to
avoid committing test artifacts).

I wasn't able to find existing automated tests covering these two scripts —
they appear to be maintainer-facing utility scripts outside the main src/
detection engine and its test suite. Is there a preferred location/pattern
for tests on scripts like these, or should I add something under tests/
following a different structure?

## Note
Saw #3150 referenced in the issue as possibly covering part of this — happy
to adjust if there's overlap.

## Also included
Added an AUTHORS.rst entry and a CHANGELOG.rst note per CONTRIBUTING.rst's
PR guidelines.