### PR TITLE
Detect lower camel case copyright holders

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -61,6 +61,7 @@ The following organizations or individuals have contributed to ScanCode:
 - Nisha Kumar @nishakm
 - Nishchith Shetty @inishchith
 - Nitish Sharma @nitish81299
+- Wonjae Park @JustinWonjaePark
 - Paul Gier @pgier
 - Philippe Ombredanne @pombredanne
 - Pi Delport @PiDelport

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 Next release
 --------------
 
+- Improve copyright holder detection for lower camel case names.
+
 - Fix the optional ``licenses`` extra dependency typo to install
   ``licensedcode-data``.
   https://github.com/aboutcode-org/scancode-toolkit/pull/5056

--- a/src/cluecode/copyrights.py
+++ b/src/cluecode/copyrights.py
@@ -286,6 +286,17 @@ class CopyrightDetector(object):
         # first, POS tag each token using token regexes
         lexed_text = list(self.lexer.lex_tokens(tokens, trace=TRACE_TOK))
 
+
+        for index, token in enumerate(lexed_text):
+            if (
+                index
+                and token.label == 'JUNK'
+                and lexed_text[index - 1].label == 'YR'
+                and token.start_line == lexed_text[index - 1].start_line
+                and re.match(r'^[a-z]{2,}[A-Z][a-z]+(?:[A-Z][a-z]+)*[\.,]?$', token.value)
+            ):
+                token.label = 'MIXEDCAP'
+
         if TRACE or TRACE_DEEP:
             logger_debug(f'CopyrightDetector: lexed tokens:')
             for l in lexed_text:

--- a/tests/cluecode/data/copyrights/lower_camel_case_holder.txt
+++ b/tests/cluecode/data/copyrights/lower_camel_case_holder.txt
@@ -1,0 +1,2 @@
+Copyright (c) 2021, drGlennPierce
+Copyright (c) 2022, myCompany

--- a/tests/cluecode/data/copyrights/lower_camel_case_holder.txt.yml
+++ b/tests/cluecode/data/copyrights/lower_camel_case_holder.txt.yml
@@ -1,0 +1,9 @@
+what:
+  - copyrights
+  - holders
+copyrights:
+  - Copyright (c) 2021, drGlennPierce
+  - Copyright (c) 2022, myCompany
+holders:
+  - drGlennPierce
+  - myCompany


### PR DESCRIPTION
## Summary

Improve copyright holder detection for lower camel case names.
- Reclassify matching `JUNK` tokens as `MIXEDCAP` when they immediately follow a copyright year on the same line.
- Restrict matching to lower camel case names to avoid broader changes to copyright parsing.

## Tests

- `venv/bin/pytest -q -p no:cacheprovider --test-suite all tests/cluecode/test_copyrights.py -k lower_camel_case_holder`
  - `1 passed`
- `git diff --check develop...HEAD`

<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [x] Updated documentation pages (not applicable)
* [x] Updated CHANGELOG.rst
