### PR TITLE
Use agpl-generic-additional-terms in SugarCRM AGPL notice rules

### DIFF
--- a/src/licensedcode/data/rules/agpl-3.0_with_agpl-generic-additional-terms_36.RULE
+++ b/src/licensedcode/data/rules/agpl-3.0_with_agpl-generic-additional-terms_36.RULE
@@ -1,10 +1,9 @@
 ---
-license_expression: agpl-3.0 AND other-copyleft
+license_expression: agpl-3.0 WITH agpl-generic-additional-terms
 is_license_notice: yes
-relevance: 100
 notes: See https://github.com/sugarcrm/Tidbit/blob/master/LICENSE
 ignorable_urls:
-    - https://www.gnu.org/licenses
+    - http://www.gnu.org/licenses
 ignorable_emails:
     - contact@sugarcrm.com
 ---
@@ -22,7 +21,7 @@ ignorable_emails:
  * details.
  *
  * You should have received a copy of the GNU Affero General Public License along with
- * this program; if not, see https://www.gnu.org/licenses or write to the Free
+ * this program; if not, see http://www.gnu.org/licenses or write to the Free
  * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
  * 02110-1301 USA.
  *

--- a/src/licensedcode/data/rules/agpl-3.0_with_agpl-generic-additional-terms_37.RULE
+++ b/src/licensedcode/data/rules/agpl-3.0_with_agpl-generic-additional-terms_37.RULE
@@ -1,9 +1,10 @@
 ---
-license_expression: agpl-3.0 AND other-copyleft
+license_expression: agpl-3.0 WITH agpl-generic-additional-terms
 is_license_notice: yes
+relevance: 100
 notes: See https://github.com/sugarcrm/Tidbit/blob/master/LICENSE
 ignorable_urls:
-    - http://www.gnu.org/licenses
+    - https://www.gnu.org/licenses
 ignorable_emails:
     - contact@sugarcrm.com
 ---
@@ -21,7 +22,7 @@ ignorable_emails:
  * details.
  *
  * You should have received a copy of the GNU Affero General Public License along with
- * this program; if not, see http://www.gnu.org/licenses or write to the Free
+ * this program; if not, see https://www.gnu.org/licenses or write to the Free
  * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
  * 02110-1301 USA.
  *


### PR DESCRIPTION
Fixes #5274

The `agpl-3.0_and_other-copyleft_1.RULE` text is the SugarCRM Tidbit license notice, which adds extra permissions/terms under sections 7(a) and 7(b) of the AGPL-3.0 -- exactly what the generic `agpl-generic-additional-terms` entry is for, as reported in the issue.

Two notes on how this is implemented:

- `agpl-generic-additional-terms` is defined with `is_exception: yes`, and all 35 existing rules that use it pair it as `agpl-3.0 WITH agpl-generic-additional-terms`. So this PR uses `WITH` rather than the `AND` suggested in the issue, for consistency with the existing `agpl-3.0_with_agpl-generic-additional-terms_*` rules. Happy to switch to `AND` if you prefer.
- `agpl-3.0_and_other-copyleft_2.RULE` is the same SugarCRM notice text (it only differs by an https vs http gnu.org URL), so it gets the same treatment.

Both rule files are renamed (`agpl-3.0_with_agpl-generic-additional-terms_36/37.RULE`) to match their new license expression.

Validation:

- `scancode-reindex-licenses` runs clean
- scanning the SugarCRM notice text now detects `agpl-3.0 WITH agpl-generic-additional-terms` with score 100
- `pytest tests/licensedcode/test_license_models.py` passes locally
- no test fixtures reference the old rule identifiers or the old expression (checked with grep over `tests/`)

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [x] Updated documentation pages (if applicable) -- not applicable
* [x] Updated CHANGELOG.rst (if applicable) -- not applicable
