### PR TITLE
Drop -c short flag from --config-file to fix duplicate parameter warning

### DIFF
--- a/docs/source/reference/scancode-cli/cli-help-text-options.rst
+++ b/docs/source/reference/scancode-cli/cli-help-text-options.rst
@@ -173,7 +173,7 @@ The following help text is displayed for ScanCode version 32.0.0:
       -n, --processes INT     Set the number of parallel processes to use. Disable
                               parallel processing if 0. Also disable threading if
                               -1. [default: (number of CPUs)-1]
-      -c, --config-file FILENAME  Path to the configuration file.
+      --config-file FILENAME  Path to the configuration file.
       -q, --quiet             Do not print summary or progress.
       -v, --verbose           Print progress as file-by-file path instead of a
                               progress bar. Print verbose scan counters.

--- a/docs/source/rst-snippets/cli-core-options.rst
+++ b/docs/source/rst-snippets/cli-core-options.rst
@@ -7,7 +7,7 @@
 
                             Default: ``(number of CPUs)-1``
 
--c, --config-file FILENAME  Path to the configuration file.
+--config-file FILENAME      Path to the configuration file.
 -v, --verbose               Print verbose file-by-file progress messages.
 
 -q, --quiet                 Do not print summary or progress messages.

--- a/src/scancode/cli.py
+++ b/src/scancode/cli.py
@@ -233,7 +233,7 @@ def default_processes():
     cls=PluggableCommandLineOption,
 )
 
-@click.option('-c', '--config-file',
+@click.option('--config-file',
     type=click.File('r'),
     required=False,
     help='Path to the configuration file.',

--- a/tests/scancode/data/help/help.txt
+++ b/tests/scancode/data/help/help.txt
@@ -136,29 +136,28 @@ Options:
                              which are todo items and needs manual review.
 
   core:
-    --ignore <pattern>          Ignore files matching <pattern>.
-    --timeout <seconds>         Stop an unfinished file scan after a timeout in
-                                seconds. [default: 120 seconds]
-    -n, --processes INT         Set the number of parallel processes to use.
-                                Disable parallel processing if 0. Also disable
-                                threading if -1. [default: (number of CPUs)-1]
-    -c, --config-file FILENAME  Path to the configuration file.
-    -q, --quiet                 Do not print summary or progress.
-    -v, --verbose               Print progress as file-by-file path instead of a
-                                progress bar. Print verbose scan counters.
-    --from-json                 Load codebase from one or more <input> JSON scan
-                                file(s).
-    --max-in-memory INTEGER     Maximum number of files and directories scan
-                                details kept in memory during a scan. Additional
-                                files and directories scan details above this
-                                number are cached on-disk rather than in memory.
-                                Use 0 to use unlimited memory and disable on-disk
-                                caching. Use -1 to use only on-disk caching.
-                                [default: 10000]
-    --max-depth INTEGER         Maximum nesting depth of subdirectories to scan.
-                                Descend at most INTEGER levels of directories
-                                below and including the starting directory. Use 0
-                                for no scan depth limit.
+    --ignore <pattern>       Ignore files matching <pattern>.
+    --timeout <seconds>      Stop an unfinished file scan after a timeout in
+                             seconds. [default: 120 seconds]
+    -n, --processes INT      Set the number of parallel processes to use. Disable
+                             parallel processing if 0. Also disable threading if
+                             -1. [default: (number of CPUs)-1]
+    --config-file FILENAME   Path to the configuration file.
+    -q, --quiet              Do not print summary or progress.
+    -v, --verbose            Print progress as file-by-file path instead of a
+                             progress bar. Print verbose scan counters.
+    --from-json              Load codebase from one or more <input> JSON scan
+                             file(s).
+    --max-in-memory INTEGER  Maximum number of files and directories scan details
+                             kept in memory during a scan. Additional files and
+                             directories scan details above this number are cached
+                             on-disk rather than in memory. Use 0 to use unlimited
+                             memory and disable on-disk caching. Use -1 to use
+                             only on-disk caching.  [default: 10000]
+    --max-depth INTEGER      Maximum nesting depth of subdirectories to scan.
+                             Descend at most INTEGER levels of directories below
+                             and including the starting directory. Use 0 for no
+                             scan depth limit.
 
   documentation:
     -h, --help       Show this message and exit.

--- a/tests/scancode/data/help/help_linux.txt
+++ b/tests/scancode/data/help/help_linux.txt
@@ -138,29 +138,28 @@ Options:
                              which are todo items and needs manual review.
 
   core:
-    --ignore <pattern>          Ignore files matching <pattern>.
-    --timeout <seconds>         Stop an unfinished file scan after a timeout in
-                                seconds. [default: 120 seconds]
-    -n, --processes INT         Set the number of parallel processes to use.
-                                Disable parallel processing if 0. Also disable
-                                threading if -1. [default: (number of CPUs)-1]
-    -c, --config-file FILENAME  Path to the configuration file.
-    -q, --quiet                 Do not print summary or progress.
-    -v, --verbose               Print progress as file-by-file path instead of a
-                                progress bar. Print verbose scan counters.
-    --from-json                 Load codebase from one or more <input> JSON scan
-                                file(s).
-    --max-in-memory INTEGER     Maximum number of files and directories scan
-                                details kept in memory during a scan. Additional
-                                files and directories scan details above this
-                                number are cached on-disk rather than in memory.
-                                Use 0 to use unlimited memory and disable on-disk
-                                caching. Use -1 to use only on-disk caching.
-                                [default: 10000]
-    --max-depth INTEGER         Maximum nesting depth of subdirectories to scan.
-                                Descend at most INTEGER levels of directories
-                                below and including the starting directory. Use 0
-                                for no scan depth limit.
+    --ignore <pattern>       Ignore files matching <pattern>.
+    --timeout <seconds>      Stop an unfinished file scan after a timeout in
+                             seconds. [default: 120 seconds]
+    -n, --processes INT      Set the number of parallel processes to use. Disable
+                             parallel processing if 0. Also disable threading if
+                             -1. [default: (number of CPUs)-1]
+    --config-file FILENAME   Path to the configuration file.
+    -q, --quiet              Do not print summary or progress.
+    -v, --verbose            Print progress as file-by-file path instead of a
+                             progress bar. Print verbose scan counters.
+    --from-json              Load codebase from one or more <input> JSON scan
+                             file(s).
+    --max-in-memory INTEGER  Maximum number of files and directories scan details
+                             kept in memory during a scan. Additional files and
+                             directories scan details above this number are cached
+                             on-disk rather than in memory. Use 0 to use unlimited
+                             memory and disable on-disk caching. Use -1 to use
+                             only on-disk caching.  [default: 10000]
+    --max-depth INTEGER      Maximum nesting depth of subdirectories to scan.
+                             Descend at most INTEGER levels of directories below
+                             and including the starting directory. Use 0 for no
+                             scan depth limit.
 
   documentation:
     -h, --help       Show this message and exit.


### PR DESCRIPTION
Fixes #5265

As suspected in the issue, commit 1c04c47 (the new `--config-file` option) is the culprit: it declared `-c` as its short flag, which collides with the long-standing `-c`/`--copyright` option from the copyright scanner plugin (`src/cluecode/plugin_copyright.py`). click then emits the `UserWarning: The parameter -c is used more than once` on every invocation.

Fix: drop the `-c` short flag from `--config-file`, keeping `-c` for `--copyright` as documented everywhere. Since `--config-file` has not shipped in any release yet (no tag contains 1c04c47), this is not a breaking change for released users.

Also updated:

- `tests/scancode/data/help/help.txt` regenerated with `SCANCODE_REGEN_TEST_FIXTURES` (the whole `core:` group re-flows because that row set the option column width); the same regenerated `core:` block applied to `help_linux.txt`
- the two docs pages that embed the help row (`docs/source/rst-snippets/cli-core-options.rst`, `docs/source/reference/scancode-cli/cli-help-text-options.rst`)

Validation:

- `scancode -c --json-pp out.json <file>` no longer emits the warning and the copyright scan works
- `pytest tests/scancode/test_cli.py tests/scancode/test_ignore.py` passes locally (including the `--config-file` tests added with the original commit)

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [x] Updated documentation pages (if applicable)
* [x] Updated CHANGELOG.rst (if applicable) -- not applicable, the option is unreleased
