### PR TITLE
Use quoted variabled for path with spaces

### DIFF
--- a/docs/source/getting-started/installation/install-scancode-using-docker.rst
+++ b/docs/source/getting-started/installation/install-scancode-using-docker.rst
@@ -64,7 +64,7 @@ apache-2.0.LICENSE directory. The JSON results will be in scan-result.json
 
 .. code-block:: shell
 
-    docker run -v $PWD/:/project scancode-toolkit -clipeu --json-pp /project/scan-result.json /project/apache-2.0.LICENSE
+    docker run -v "$PWD/:/project" scancode-toolkit -clipeu --json-pp /project/scan-result.json /project/apache-2.0.LICENSE
 
 This will mount your current working from the host into ``/project`` in the container
 and then scan the contents. The output ``result.json`` will be written back to your


### PR DESCRIPTION
If $PWD contains spaces, the command breaks without quotes.

<!-- Delete Template sections if unneccesary -->
<!-- Add issue number here (We encourage you to create the Issue First) -->
<!-- You can also link the issue in Commit Messages -->

Fixes #0000

<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [ ] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [ ] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [ ] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [ ] Updated documentation pages (if applicable)
* [ ] Updated CHANGELOG.rst (if applicable)
<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
