### PR TITLE
fix(copyright): detect year ranges ending with 'NOW'

### DIFF
--- a/src/cluecode/copyrights.py
+++ b/src/cluecode/copyrights.py
@@ -638,7 +638,8 @@ _YEAR_YEAR_PUNCT = _YEAR_YEAR + _PUNCT
 _YEAR_SHORT_PUNCT = _YEAR_SHORT + _PUNCT
 _YEAR_OR_YEAR_YEAR_WITH_PUNCT = fr'({_YEAR_PUNCT}|{_YEAR_YEAR_PUNCT})'
 _YEAR_THEN_YEAR_SHORT = fr'({_YEAR_OR_YEAR_YEAR_WITH_PUNCT}({_YEAR_SHORT_PUNCT})*)'
-_YEAR_DASH_PRESENT = _YEAR + r'[\-~]? ?[Pp]resent\.?,?'
+_YEAR_DASH_PRESENT = '(?:' + _YEAR + ')' + r'[\-~]? ?[Pp]resent\.?,?'
+_YEAR_DASH_NOW = '(?:' + _YEAR + ')' + r'[\-~]? ?[Nn][Oo][Ww]\.?,?'
 
 PATTERNS = [
     ############################################################################
@@ -2168,6 +2169,8 @@ PATTERNS = [
     (r'^(' + _YEAR_YEAR + ')+$', 'YR'),
 
     (r'^(' + _YEAR_DASH_PRESENT + ')+$', 'YR'),
+
+    (r'^(' + _YEAR_DASH_NOW + ')+$', 'YR'),
 
     # ISO dates as in 2024-12-09
     (r'^' + _YEAR + '-(0?[1-9]|1[012])-(0?[1-9]|[12][0-9]|3[01])$', 'YR'),


### PR DESCRIPTION
Fixes #5220

## Summary
Added support for copyright year ranges ending with 'NOW' (case-insensitive) such as '2013-NOW', '2013-Now', '2013-now', similar to existing 'Present' support.

## Changes
- Added _YEAR_DASH_NOW pattern for year ranges ending with NOW
- Fixed _YEAR_DASH_PRESENT grouping with non-capturing group
- Added pattern to PATTERNS list

## Testing
- Verified detection of: '2013-NOW', '2013-Now', '2013-now', '2013-NOW', '2020-NOW Company', '1999-present Company'
- Verified 'Present' still works correctly