### PR TITLE
Add new license mckr-1.0 for the MCKR license version 1.0

### DIFF
--- a/src/licensedcode/data/licenses/mckr-1.0.LICENSE
+++ b/src/licensedcode/data/licenses/mckr-1.0.LICENSE
@@ -1,0 +1,145 @@
+---
+key: mckr-1.0
+short_name: MCKR 1.0
+name: MCKR License 1.0
+category: Free Restricted
+owner: AmirHosein Sadeghimanesh and Elisenda Feliu
+homepage_url: https://github.com/Hovakhshatra/MCKR_App/blob/main/LICENSE
+spdx_license_key: LicenseRef-scancode-mckr-1.0
+text_urls:
+    - https://raw.githubusercontent.com/Hovakhshatra/MCKR_App/main/LICENSE
+ignorable_copyrights:
+    - AmirHosein Sadeghimanesh, Elisenda Feliu Copyright (c) 2020
+    - Copyright (c) 2020 Furthermore
+ignorable_holders:
+    - AmirHosein Sadeghimanesh, Elisenda Feliu
+    - Furthermore
+ignorable_authors:
+    - AmirHosein Sadeghimanesh, Elisenda Feliu
+ignorable_urls:
+    - https://julialang.org/
+---
+
+                                  MCKR version 1.0
+                   Authors: AmirHosein Sadeghimanesh, Elisenda Feliu
+                                 Copyright (C) 2020
+
+                                      *NOTICE*
+
+This program is free software in that it is free to download (as source code or as a binary) 
+and free to use on the computer(s) to which it was downloaded.  However, there are several 
+restrictions on its redistribution and its use in other programs, as indicated below. 
+
+This software is written using Julia version 1.4.2. To run it the user may need Julia being 
+installed on its system. Julia is an open source programming language under MIT license. To 
+download or install Julia and see the license of Julia visit its website https://julialang.org.
+
+0. Definitions
+
+"The Program" refers to any copyrightable work licensed under this licence.  Each licensee 
+is addressed as "you" and may be any individual or an organization.
+
+To "modify" a work means to copy from or adapt all or part of the work in a fashion requiring 
+copyright permission, other than the making of an exact copy. The resulting work is called a 
+“modified version” of the earlier work or a work “based on” the earlier work.
+
+To "propagate" a work means to do anything with it that, without permission, would make you 
+directly or secondarily liable for infringement under applicable copyright law, except executing 
+it on a computer or modifying a private copy. Propagation includes copying, distribution (with or 
+without modification), or making available to the public.
+
+To "convey" a work means any kind of propagation that enables other parties to make or receive 
+copies. Mere interaction with a user through a computer network, with no transfer of a copy, is 
+not conveying.
+
+A "Standard Interface" means an interface that either is an official standard defined by a 
+recognized standards body, or, in the case of interfaces specified for a particular programming 
+language, one that is widely used among developers working in that language.
+
+A "covered work" means any work that in any way makes use of any part of the Program.  This 
+includes, but is not restricted to, software that makes calls to any part of the MCKR software 
+package, in any form.
+
+1. Basic Permissions.
+
+All rights granted under this License are granted for the term of copyright on the Program, 
+and are irrevocable provided the stated conditions are met. This License explicitly affirms 
+your unlimited permission to run the unmodified Program.
+
+2. Conveying Verbatim Copies.
+
+You may convey verbatim copies of the Program's source code as you receive it, in any 
+medium, provided that you conspicuously and appropriately publish on each copy an appropriate 
+copyright notice; keep intact all notices stating that this License applies to the Program; 
+keep intact all notices of the absence of any warranty; and give all recipients a copy of 
+this License along with the Program.  
+
+You may not charge a fee for any copy that you convey, and you may not offer support or 
+warranty protection for a fee. 
+
+3. Conveying Modified Versions.
+
+You may modify the Program for your private use only.  You may not convey, in any manner, a 
+modified version of the Program without written consent of all Authors of the Program.   
+
+4. Conveying Covered Work.
+
+The Program may be used in covered work.  However, the following must be 
+displayed in the Standard Interface of the covered work:
+
+MCKR version 0.1.0
+Authors: AmirHosein Sadeghimanesh, Elisenda Feliu
+Copyright (C) 2020
+
+Furthermore, if a covered work is conveyed, a verbatim copy of the Program's 
+source code must be conveyed simultaneously, as described in Section 2 of this License.
+
+You may not charge a fee for any copy of any covered work without the written permission of 
+all Authors of the Program.
+
+5. Termination.
+
+You may not propagate, modify, or convey a covered work except as expressly provided under 
+this License. Any attempt otherwise to propagate, modify, or convey it will automatically 
+terminate your rights under this License.
+
+6. No Surrender of Others' Freedom.
+
+If conditions are imposed on you (whether by court order, agreement or otherwise) that 
+contradict the conditions of this License, they do not excuse you from the conditions of this 
+License. If you cannot convey a covered work so as to satisfy simultaneously your obligations 
+under this License and any other pertinent obligations, then as a consequence you may not 
+convey it at all. 
+
+7. Disclaimer of Warranty.
+
+THERE IS NO WARRANTY OF ANY KIND FOR THE PROGRAM. EXCEPT WHEN OTHERWISE STATED IN WRITING THE 
+COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM “AS IS” WITHOUT WARRANTY OF ANY KIND, 
+EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE 
+RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE 
+DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+8. Limitation of Liability
+
+IN NO EVENT UNLESS AGREED TO IN WRITING, WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO 
+MODIFIES AND/OR CONVEYS THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING 
+ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO 
+USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE 
+OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH 
+ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE 
+POSSIBILITY OF SUCH DAMAGES.
+
+9. Interpretation of Sections 7 and 8.
+
+If the disclaimer of warranty and limitation of liability provided above cannot be given local 
+legal effect according to their terms, reviewing courts shall apply local law that most closely 
+approximates an absolute waiver of all civil liability in connection with the Program, unless a 
+warranty or assumption of liability accompanies a copy of the Program in return for a fee.
+
+END OF TERMS AND CONDITIONS
+
+In addition to the stated license, we ask that any publications which made use of MCKR, 
+directly or indirectly via a covered work, include an appropriate citation to MCKR, as 
+described on the README file in the GitHub repository of MCKR, or any future MCKR 
+page created by the Authors.


### PR DESCRIPTION
Fixes #5275

Adds `mckr-1.0` for the MCKR license version 1.0 (a GPL-derived license by AmirHosein Sadeghimanesh and Elisenda Feliu with additional restrictions on redistribution and use in other programs), text from the homepage URL in the issue.

`category: Free Restricted` since it is free to download and use but restricts propagation; `owner` set to the authors named in the license header.

Detection before this change: the text matched a spurious combination of `mit`, `infineon-free` and unknown license references. It now detects as `mckr-1.0` with score 100.

Validation (same for all six license additions from this batch):

- `scancode-reindex-licenses` runs clean
- self-detection and ignorables validation tests pass (`--test-suite=validate tests/licensedcode/test_detection_validate.py`), with ignorables generated by the test regen tooling rather than by hand
- `pytest tests/licensedcode/test_license_models.py` passes locally

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [x] Updated documentation pages (if applicable) -- not applicable
* [x] Updated CHANGELOG.rst (if applicable) -- not applicable
