### PR TITLE
Fix CI breakage with click 8.5.0: declare explicit default for --only-findings

### DIFF
--- a/src/scancode/plugin_only_findings.py
+++ b/src/scancode/plugin_only_findings.py
@@ -21,6 +21,7 @@ class OnlyFindings(OutputFilterPlugin):
 
     options = [
         PluggableCommandLineOption(('--only-findings',), is_flag=True,
+            default=False,
             help='Only return files or directories with findings for the '
                  'requested scans. Files and directories without findings are '
                  'omitted (file information is not treated as findings).',


### PR DESCRIPTION
All the `*_latest_from_pip` CI jobs fail since 2026-08-26 on every PR (e.g. this PR's runs and #5271's) with:

```
FAILED tests/scancode/test_cli.py::test_can_call_run_scan_as_a_function - AssertionError: assert 1 == 2
```

Root cause: click 8.5.0 (released 2026-08-26 13:33 UTC, right when the failures started) exposes `Sentinel.UNSET` as the `.default` of options declared without an explicit default -- and that sentinel is **truthy**. `run_scan()` builds its option set from raw `.default` values (`{clio.name: clio.default for clio in plugin_options}`), so `only_findings` became truthy, the only-findings output filter silently activated on every function-API scan, and findingless resources (the directory entry in the test) were dropped from the results. The CLI path is unaffected because click resolves the sentinel at parse time.

Bisected by installing the repo with latest deps (fails), downgrading only click to 8.4.2 (passes), and re-upgrading to 8.5.0 (fails again). An audit of all plugin options shows `--only-findings` was the only one declared without an explicit default, so declaring `default=False` is the complete fix; it is a no-op on older click versions (verified: the test and the only-findings plugin tests pass on both click 8.4.2 and 8.5.0 locally).

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [x] Updated documentation pages (if applicable) -- not applicable
* [x] Updated CHANGELOG.rst (if applicable) -- not applicable
