### PR TITLE
Add full license text rule for the Jakub Jirak proprietary license

### DIFF
--- a/src/licensedcode/data/rules/proprietary-license_1064.RULE
+++ b/src/licensedcode/data/rules/proprietary-license_1064.RULE
@@ -1,0 +1,14 @@
+---
+license_expression: proprietary-license
+is_license_text: yes
+notes: proprietary license text of Jakub Jirak as seen in https://github.com/JirakJ/lincense
+    reported in scancode-toolkit issue 5290
+ignorable_copyrights:
+    - Copyright (c) 2025 Jakub Jirak
+ignorable_holders:
+    - Jakub Jirak
+ignorable_emails:
+    - support@jakubjirak.com
+---
+
+Copyright (c) 2025 Jakub Jirák. All rights reserved.  This software and its source code are proprietary and confidential. Unauthorized copying, modification, distribution, or reverse engineering of this software, via any medium, is strictly prohibited.  You are granted a non-exclusive, non-transferable license to use this software only in accordance with the terms agreed upon at the time of purchase or download.  For licensing or support inquiries, contact: support@jakubjirak.com


### PR DESCRIPTION
Fixes #5290

The license text at the URL in the issue was detected as `proprietary-license` but only through two partial fragment matches (scores 90 and 10.87). This adds the complete text as a new `proprietary-license` full-text rule (`proprietary-license_1064.RULE`, with the ignorables generated by the validation test regen tooling), so the text now detects in full:

```
proprietary-license score=100.0 rule=proprietary-license_1064.RULE
```

Validation: `scancode-reindex-licenses` clean; the self-detection and ignorables validation tests for the new rule pass.

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
