### PR TITLE
Removing assignes and removing label new-license in Bug Report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/--bug-report.md
+++ b/.github/ISSUE_TEMPLATE/--bug-report.md
@@ -2,8 +2,7 @@
 name: "\U0001F41B Bug report"
 about: Create a report to help us improve
 title: ''
-labels: bug, new-license
-assignees: hesa
+labels: bug
 
 ---
 


### PR DESCRIPTION
This commit fixes:
* the incorrect assignment of hesa to the issue
* the incorrectly added label new-license to the issue

Fixes #5304 

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [X] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [ ] Updated documentation pages (if applicable)
* [ ] Updated CHANGELOG.rst (if applicable)
